### PR TITLE
Use long names

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
 {% set name = "ncrc" %}
-{% set version = "1.16" %}
+{% set version = "1.17" %}
 
 package:
   name: {{ name }}

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -187,7 +187,7 @@ class Client:
                 app_list = ['\t' + x.split()[0].replace('ncrc-', '')
                             for x in std_out[0].split('\n')[3:-1:]]
                 unique_apps = '\n'.join(set(app_list))
-                print('# Use \'ncrc search app\' to list more detail\n# NCRC',
+                print('# Use \'ncrc search name-of-application\' to list more detail\n# NCRC',
                       'applications available:\n\n%s' % (unique_apps))
             else:
                 conda_api.run_command(*run_command,

--- a/ncrc/version.py
+++ b/ncrc/version.py
@@ -1,1 +1,1 @@
-version_str = "1.16"
+version_str = "1.17"


### PR DESCRIPTION
Remove the short name in favor of being more discriptive.

Closes #45