### PR TITLE
56 more robust downloads

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,22 @@
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=import-error,
+        c-extension-no-member

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
 {% set name = "ncrc" %}
-{% set version = "1.19" %}
+{% set version = "1.20" %}
 
 package:
   name: {{ name }}

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -262,6 +262,16 @@ class Client:
         except AttributeError:
             pass
 
+        # rename the local_ json meta file to its proper name had conda installed it normally.
+        # this allows NCRC packages to be listed among `conda list` after installation
+        json_file = local_file.replace('tar.bz2', 'json')
+        json_path = os.path.join(self.conda_info['envs_dirs'][0],
+                                 '-'.join(name_variant),
+                                 'conda-meta',
+                                 os.path.basename(json_file))
+        if os.path.exists(json_path):
+            os.rename(json_path, json_path.replace('local_',''))
+
         print(f'\nInstallation Complete. To use {self.__args.application}, activate the'
                   f'\nenvironment:\n\n\tconda activate {"-".join(name_variant)}\n\nDocumentation '
                   'is locally available by activating this\nenvironment and then pointing your web '

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -224,7 +224,8 @@ class Client:
         else:
             print(f'\nNot downloading {os.path.basename(url)}.\nUsing local copy already '
                   'available. If you suspect an\nissue with this file, consider running:'
-                  '\n\n\tconda clean --all --yes\n\nand then try again.\n')
+                  '\n\n\tconda clean --all --yes\n\nand then try again. A new copy will be '
+                  'downloaded.\n')
         return file_path
 
     def install_package(self):
@@ -263,9 +264,11 @@ class Client:
 
         print(f'\nInstallation Complete. To use {self.__args.application}, activate the'
                   f'\nenvironment:\n\n\tconda activate {"-".join(name_variant)}\n\nDocumentation '
-                  'is locally available by activating\nthis environment and then pointing your web '
-                  'browser\nto the file denoted by echoing the following variable:\n\n\techo '
-                  f'${self.__args.application}_DOCS\n')
+                  'is locally available by activating this\nenvironment and then pointing your web '
+                  'browser to the\nfile denoted by echoing the following variable:\n\n\techo '
+                  f'${self.__args.application}_DOCS\n\nAdditional usage information is also '
+                  'available at\n\n\thttps://mooseframework.inl.gov/ncrc/applications/ncrc_conda_'
+                  f'{self.__args.application}.html\n\n')
 
     def search_package(self):
         """ Search for package, and report a formatted list """

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -187,11 +187,15 @@ class Client:
         User Conda's Solver to get real tarball URL. As well as dependency information.
         We need the moose-dev version this package was built with.
         """
+        pkg_variant = list(filter(None, [self.__args.package,
+                                         self.__args.version,
+                                         self.__args.build]))
         solver = Solver(prefix='',
                         channels=["https://conda.software.inl.gov/ncrc-applications",
                                   "https://conda.software.inl.gov/public",
                                   "conda-forge"],
-                                  specs_to_add=[f'ncrc-{self.__args.application}'])
+                                  specs_to_add=[f'{"=".join(pkg_variant)}'])
+        print(f'Solving requirements for {self.__args.application}...')
         with suppress_stdout_stderr():
             out = solver.solve_final_state()
         wrong_url = out[len(out)-1].url
@@ -207,7 +211,7 @@ class Client:
         self.conda_info = json.loads(conda_api.run_command('info', '--all', '--json')[0])
         file_path = os.path.join(self.conda_info['pkgs_dirs'][0], f'local_{os.path.basename(url)}')
         if not os.path.exists(file_path):
-            print(f'\nDownloading {os.path.basename(url)}...')
+            print(f'Downloading {os.path.basename(url)}...')
             with self.session as response:
                 raw_download = response.get(url, stream=True)
                 total_size = int(raw_download.headers.get("content-length", 0))

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -380,18 +380,6 @@ def verify_args(args):
               '\nEnter the base environment first with `conda activate base`.')
         sys.exit(1)
 
-    if (args.command == 'update' and ncrc_app is None):
-        print(' Cannot perform an update while not inside said environment. Please\n',
-              'activate the environment first and then run the command again. Use:\n',
-              '\n\tconda env list\n\nTo view available environments to activate.')
-        sys.exit(1)
-    elif (args.command == 'update' and ncrc_app and len(conda_environment.split('_')) > 1):
-        print(f' You installed a specific version of {ncrc_app}. If you wish\n',
-              'to update to the latest version, it would be best to install\n',
-              'it into a new environment instead:\n\n\tconda activate base\n\tncrc install',
-              f'{ncrc_app}\n\n or activate that environment and perform the update there.')
-        sys.exit(1)
-
     if args.insecure:
         requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 

--- a/ncrc/__main__.py
+++ b/ncrc/__main__.py
@@ -202,6 +202,8 @@ class Client:
         """
         Download url using global session (with the cookie it contains).
         """
+        # Adding this to __init__ causes Info libmamba logging!?!?!
+        #pylint: disable=attribute-defined-outside-init
         self.conda_info = json.loads(conda_api.run_command('info', '--all', '--json')[0])
         file_path = os.path.join(self.conda_info['pkgs_dirs'][0], f'local_{os.path.basename(url)}')
         if not os.path.exists(file_path):

--- a/ncrc/version.py
+++ b/ncrc/version.py
@@ -1,3 +1,3 @@
 """ Set Version """
 #pylint: disable=invalid-name
-version_str = "1.19"
+version_str = "1.20"


### PR DESCRIPTION
Use Python Requests to handle RSA Conda Package downloads, thus shifting away from needing to mock the Conda gateway connector.